### PR TITLE
script to check for differences with newly generated merged_structures

### DIFF
--- a/structure_donations/Updating_merged_structures/Updating_merged_structures_annotated.ipynb
+++ b/structure_donations/Updating_merged_structures/Updating_merged_structures_annotated.ipynb
@@ -1,0 +1,243 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 127,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pathlib import Path \n",
+    "import os\n",
+    "import glob\n",
+    "from datetime import datetime\n",
+    "\n",
+    "main_path = \"/home/rvissche/Nextcloud/What-If/what-if-data-donation/what-if-data-donation/structure_donations/\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load the annotated data for all platforms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 128,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Folder containing CSVs\n",
+    "folder_annotated = f\"{main_path}Annotated_schema_df\"\n",
+    "\n",
+    "# Dictionary to hold DataFrames\n",
+    "dfs_annotated = {}\n",
+    "\n",
+    "for file in os.listdir(folder_annotated):\n",
+    "    if file.endswith(\".csv\"):\n",
+    "        name = os.path.splitext(file)[0]\n",
+    "        path = os.path.join(folder_annotated, file)\n",
+    "        dfs_annotated[name] = pd.read_csv(path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 129,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['YT_merged_structure_annotated', 'IG_merged_structure_annotated', 'X_merged_structure_annotated', 'TT_merged_structure_annotated', 'YT_merged_column_names_annotated', 'YT_merged_structures_annotated', 'FB_merged_structure_annotated'])"
+      ]
+     },
+     "execution_count": 129,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dfs_annotated.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading the (new) merged structures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 130,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "\n",
+    "folder_new = f\"{main_path}Processed_structure_donations\"\n",
+    "\n",
+    "dfs_new = {}\n",
+    "\n",
+    "for path in glob.glob(f\"{folder_new}/**/Final/*_Merged_structures.csv\", recursive=True):\n",
+    "    name = os.path.splitext(os.path.basename(path))[0]\n",
+    "    dfs_new[name] = pd.read_csv(path)\n",
+    "\n",
+    "\n",
+    "YT_column = os.path.join(folder_new, \"Youtube/Column_names_final/YT_Merged_Column_Names.csv\")\n",
+    "if os.path.exists(YT_column):\n",
+    "    name = os.path.splitext(os.path.basename(YT_column))[0]\n",
+    "    dfs_new[name] = pd.read_csv(YT_column)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Identify the new rows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 131,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "YT_merged_structure_annotated\n",
+      "IG_merged_structure_annotated\n",
+      "TT_merged_structure_annotated\n",
+      "FB_merged_structure_annotated\n",
+      "YT_merged_column_names_annotated\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Fix X!!! 'x_merged_structure_annotated': 'x_merged_structures',\n",
+    "\n",
+    "new_rows_dict = {}\n",
+    "\n",
+    "dict_dfs = {\n",
+    "    'YT_merged_structure_annotated': 'YT_Merged_structures',\n",
+    "    'IG_merged_structure_annotated': 'IG_Merged_structures',\n",
+    "    'TT_merged_structure_annotated': 'TT_Merged_structures',\n",
+    "    'FB_merged_structure_annotated': 'FB_Merged_structures',\n",
+    "    'YT_merged_column_names_annotated': 'YT_Merged_Column_Names'\n",
+    "\n",
+    "}\n",
+    "\n",
+    "for k,v in dict_dfs.items():\n",
+    "    \n",
+    "    dfs_annotated[f'{k}'] = dfs_annotated[k].loc[:, ~dfs_annotated[k].columns.str.startswith('Unnamed')]\n",
+    "\n",
+    "    print(k)\n",
+    "\n",
+    "    merge_cols = list(dfs_annotated[k].columns)\n",
+    "\n",
+    "    if 'keepID' in merge_cols:\n",
+    "        merge_cols.remove('keepID')\n",
+    "    if 'keep_id' in merge_cols:\n",
+    "        merge_cols.remove('keep_id')\n",
+    "    if 'date_added' in merge_cols:\n",
+    "        merge_cols.remove('date_added')\n",
+    "\n",
+    "\n",
+    "    new_rows_dict[f'{v}_new'] = dfs_new[v].merge(dfs_annotated[k], how=\"left\", on = merge_cols, indicator=True).query('_merge == \"left_only\"').drop(columns=[\"_merge\"])\n",
+    "    \n",
+    "    date_col = 'date_added'\n",
+    "\n",
+    "    if date_col not in new_rows_dict[f'{v}_new'].columns:\n",
+    "        new_rows_dict[f'{v}_new'][date_col] = datetime.now().strftime(\"%Y-%m-%d\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Append the new rows to the annotated merged structure\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 133,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for k,v in dict_dfs.items():\n",
+    "\n",
+    "    date_col = 'date_added'\n",
+    "    if date_col not in dfs_annotated[f'{k}'].columns:\n",
+    "         dfs_annotated[f'{k}'][date_col] = 'pre-trial'\n",
+    "    \n",
+    "\n",
+    "    dfs_annotated[f'{k}'] = pd.concat([dfs_annotated[f'{k}'], new_rows_dict[f'{v}_new']], ignore_index=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save annotated merged structures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 134,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved YT_merged_structure_annotated.csv (1049 rows)\n",
+      "Saved IG_merged_structure_annotated.csv (999 rows)\n",
+      "Saved X_merged_structure_annotated.csv (572 rows)\n",
+      "Saved TT_merged_structure_annotated.csv (999 rows)\n",
+      "Saved YT_merged_column_names_annotated.csv (240 rows)\n",
+      "Saved YT_merged_structures_annotated.csv (94 rows)\n",
+      "Saved FB_merged_structure_annotated.csv (2917 rows)\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "folder_annotated = f\"{main_path}Annotated_schema_df\"\n",
+    "\n",
+    "# Assume dfs_dict is your dictionary of DataFrames\n",
+    "for key, df in dfs_annotated.items():\n",
+    "    # Create a filename from the key\n",
+    "    filename = f\"{key}.csv\"\n",
+    "    path = os.path.join(folder_annotated, filename)\n",
+    "    \n",
+    "    # Save DataFrame to CSV\n",
+    "    df.to_csv(path, index=False)\n",
+    "    print(f\"Saved {filename} ({len(df)} rows)\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "data-donations",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This script looks for new rows that are not in the annotated merged_structures. It adds a timestamp to indicate the new rows. Then, this df is appended to the annotated merged_structures.  The researcher can then mark whether the rows should be kept or not and can do the ID identification. 